### PR TITLE
Allow accents in team names

### DIFF
--- a/src/Fetchers/TMSFetcher/TMSMatchFetcher.ts
+++ b/src/Fetchers/TMSFetcher/TMSMatchFetcher.ts
@@ -133,7 +133,7 @@ export class TMSMatchFetcher {
             .normalize("NFD")
             .replace(/[\u0300-\u036f]/g, "")
             .match(
-                /^(?:([A-Za-z0-9/&' -]+) )?v (?:([A-Za-z0-9/&' -]+))?(?: \((.+)\))?$/);
+                /^(?:([A-Za-z0-9/&' -]+) )?v ([A-Za-z0-9/&' -]+)?(?: \((.+)\))?$/);
 
             if (!result) {
                 throw new Error("Couldn't extract data from match title: " + title);

--- a/src/Fetchers/TMSFetcher/TMSMatchFetcher.ts
+++ b/src/Fetchers/TMSFetcher/TMSMatchFetcher.ts
@@ -133,7 +133,7 @@ export class TMSMatchFetcher {
             .normalize("NFD")
             .replace(/[\u0300-\u036f]/g, "")
             .match(
-                /^(?:([A-Za-z0-9/& -]+) )?v (?:([A-Za-z0-9/& -]+))?(?: \((.+)\))?$/);
+                /^(?:([A-Za-z0-9/&' -]+) )?v (?:([A-Za-z0-9/&' -]+))?(?: \((.+)\))?$/);
 
             if (!result) {
                 throw new Error("Couldn't extract data from match title: " + title);

--- a/tests/src/Fetchers/TMSFetcher/TMSMatchFetcher.test.ts
+++ b/tests/src/Fetchers/TMSFetcher/TMSMatchFetcher.test.ts
@@ -50,6 +50,15 @@ describe("TMSMatchFetcher tests", () => {
                 });
             });
 
+            test("Teams including accents", () => {
+                runParseTitleTest({
+                    in: "B'ham v LoremIpsum (With MT)",
+                    home: "B'ham",
+                    away: "LoremIpsum",
+                    type: "With MT"
+                });
+            });
+
             test("Invalid input", () => {
                 expect(() => runParseTitleTest({ in: "Random string" }))
                     .toThrowError();


### PR DESCRIPTION
Closes #109

## Proposed Changes
_Explain the changes you've made with this PR_

- Allow accents in team names to prevent the England hockey fetcher from breaking.

## Checklist

- [x] I have read the [contribution document](https://github.com/Martijn-van-Kekem-Development/hockey-match-calendar/blob/main/CONTRIBUTING.md).
- [x] I have added test cases to cover my changes (if applicable).
- [x] All new and existing test cases have passed.
- [x] My code adheres to the coding style of this project.
