### PR TITLE
Add FIH links to match events

### DIFF
--- a/src/Fetchers/FIHFetcher/FIHCompetitionFetcher.ts
+++ b/src/Fetchers/FIHFetcher/FIHCompetitionFetcher.ts
@@ -1,6 +1,8 @@
 import { Competition } from "../../Objects/Competition.js";
 import { APIHelper } from "../../Utils/APIHelper";
 import { FIHFetcher } from "./FIHFetcher.js";
+import { Abbreviations } from "../../Utils/Abbreviations.js";
+import { Gender } from "../../Objects/Gender.js";
 
 export class FIHCompetitionFetcher {
     /**
@@ -89,6 +91,26 @@ export class FIHCompetitionFetcher {
         object.setType(type.trim());
 
         return object;
+    }
+
+    /**
+     * Get the URL to fetch the matches from.
+     * @param competition The competition to fetch for.
+     * @private
+     */
+    public static getCompetitionPath(competition: Competition) {
+        const title = competition.getName().toLowerCase()
+            .replace(/ /g, "-").replace(/[^a-z0-9-]/g, "");
+
+        const gender =
+            Abbreviations.getGender(competition.getType(), competition.getFetcher());
+
+        let genderString = "other";
+        if (gender == Gender.MEN) genderString = "men";
+        else if (gender == Gender.WOMEN) genderString = "women";
+
+        return `${FIHFetcher.FIH_BASE_URL}/events/others/${genderString}/${
+            title}-${competition.getID()}`;
     }
 }
 

--- a/src/Fetchers/FIHFetcher/FIHFetcher.ts
+++ b/src/Fetchers/FIHFetcher/FIHFetcher.ts
@@ -106,9 +106,23 @@ export class FIHFetcher extends Fetcher {
     /**
      * @override
      */
-    descriptionToAppend(competition: Competition, match: Match): string[] {
+    descriptionToAppend(competition: Competition, match: Match,
+                        html: boolean): string[] {
         const lines: string[] = [];
         lines.push("Stage: " + match.getType());
+        lines.push();
+
+        // Add TMS links
+        const url = FIHCompetitionFetcher.getCompetitionPath(competition);
+        const matchUrl = FIHMatchFetcher.getMatchPath(competition, match);
+        if (html) {
+            lines.push(`<a href="${matchUrl}">View match details</a>`);
+            lines.push(`<a href="${url}">View competition details</a>`);
+        } else {
+            lines.push(`Match link: ${matchUrl}`);
+            lines.push(`Competition link: ${url}`);
+        }
+
         return lines;
     }
 

--- a/src/Objects/Match.ts
+++ b/src/Objects/Match.ts
@@ -86,6 +86,12 @@ export class Match {
     private id: string | null = null;
 
     /**
+     * The metadata for this match.
+     * @private
+     */
+    private metadata: Record<string, string> = {};
+
+    /**
      * The match officials.
      * @private
      */
@@ -192,6 +198,15 @@ export class Match {
     }
 
     /**
+     * Set a metadata item.
+     * @param key The key to set.
+     * @param value The value to set.
+     */
+    public setMetadata(key: string, value: string) {
+        this.metadata[key] = value;
+    }
+
+    /**
      * Set the match competition.
      * @param event The match competition.
      */
@@ -284,7 +299,7 @@ export class Match {
      */
     public getICSAttributes(): Record<string, string> {
         return {
-            UID: this.getMatchID(),
+            UID: this.getID(),
             ...this.getDateICSAttributes(),
             SUMMARY: this.getMatchTitle(),
             LOCATION: this.getLocation(),
@@ -328,6 +343,14 @@ export class Match {
         else if (venue.length > 0 && location.length === 0) return venue;
         else if (venue.length === 0 && location.length > 0) return location;
         else return `${venue} | ${location}`;
+    }
+
+    /**
+     * Get a metadata item.
+     * @param key The key to retrieve.
+     */
+    public getMetadata(key: string): string {
+        return this.metadata[key];
     }
 
     /**
@@ -388,16 +411,6 @@ export class Match {
         return lines.join(html ? "<br>" : "\\n");
     }
 
-    // Append fetcher description (for links and any fetcher-specific data)
-    private appendFetcherDescription(lines: string[], includeHTML: boolean) {
-        if (this.competition && this.competition.getFetcher()) {
-            lines.push(...this.competition.getFetcher()
-                .descriptionToAppend(this.competition, this, includeHTML));
-        }
-
-        return lines.join("\\n");
-    }
-
     /**
      * Get the title for this match.
      */
@@ -408,13 +421,6 @@ export class Match {
 
         return `${icon}${competitionAbbr} ${
             this.getAbbr()} | ${this.getHomeTeam()} - ${this.getAwayTeam()}`;
-    }
-
-    /**
-     * Get the match ID.
-     */
-    public getMatchID(): string {
-        return this.id;
     }
 
     /**


### PR DESCRIPTION
Closes #120 

## Proposed Changes
_Explain the changes you've made with this PR_

- Add separate functions for retrieving competition and match paths.
- Add path to the description of FIH matches.
- Add the ability to add generic metadata to a match.

## Checklist

- [x] I have read the [contribution document](https://github.com/Martijn-van-Kekem-Development/hockey-match-calendar/blob/main/CONTRIBUTING.md).
- [x] I have added test cases to cover my changes (if applicable).
- [x] All new and existing test cases have passed.
- [x] My code adheres to the coding style of this project.
